### PR TITLE
Add screen unlock broadcast handling to FooScreenListener

### DIFF
--- a/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
+++ b/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
@@ -27,6 +27,8 @@ public class FooScreenListener
 
         void onScreenOn();
 
+        void onUserLocked();
+
         void onUserUnlocked();
     }
 
@@ -63,6 +65,16 @@ public class FooScreenListener
                         for (FooScreenListenerCallbacks callbacks : mListenerManager.beginTraversing())
                         {
                             callbacks.onScreenOn();
+                        }
+                        mListenerManager.endTraversing();
+                    }
+
+                    @Override
+                    public void onUserLocked()
+                    {
+                        for (FooScreenListenerCallbacks callbacks : mListenerManager.beginTraversing())
+                        {
+                            callbacks.onUserLocked();
                         }
                         mListenerManager.endTraversing();
                     }
@@ -170,6 +182,7 @@ public class FooScreenListener
                     intentFilter.addAction(Intent.ACTION_SCREEN_OFF); // API 1
                     intentFilter.addAction(Intent.ACTION_SCREEN_ON); // API 1
                     intentFilter.addAction(Intent.ACTION_USER_PRESENT); // API 1
+                    intentFilter.addAction(Intent.ACTION_USER_LOCKED); // API 24
                     intentFilter.addAction(Intent.ACTION_USER_UNLOCKED); // API 24
                     mContext.registerReceiver(this, intentFilter);
                 }
@@ -215,6 +228,9 @@ public class FooScreenListener
                 }
                 case Intent.ACTION_USER_PRESENT:
                     mCallbacks.onUserUnlocked();
+                    break;
+                case Intent.ACTION_USER_LOCKED:
+                    mCallbacks.onUserLocked();
                     break;
                 case Intent.ACTION_USER_UNLOCKED:
                     mCallbacks.onUserUnlocked();

--- a/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
+++ b/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
@@ -169,6 +169,8 @@ public class FooScreenListener
                     IntentFilter intentFilter = new IntentFilter();
                     intentFilter.addAction(Intent.ACTION_SCREEN_OFF); // API 1
                     intentFilter.addAction(Intent.ACTION_SCREEN_ON); // API 1
+                    intentFilter.addAction(Intent.ACTION_USER_PRESENT); // API 1
+                    intentFilter.addAction(Intent.ACTION_USER_UNLOCKED); // API 24
                     mContext.registerReceiver(this, intentFilter);
                 }
             }
@@ -211,6 +213,9 @@ public class FooScreenListener
                     }
                     break;
                 }
+                case Intent.ACTION_USER_PRESENT:
+                    mCallbacks.onUserUnlocked();
+                    break;
                 case Intent.ACTION_USER_UNLOCKED:
                     mCallbacks.onUserUnlocked();
                     break;


### PR DESCRIPTION
## Summary
- register `FooScreenListener` for user-present and user-unlocked broadcasts
- invoke `FooScreenListenerCallbacks.onUserUnlocked` when the device becomes available after unlock events

## Testing
- `./gradlew :smartfoo-android-lib-core:test` *(fails: missing Android SDK configuration in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d708d044088333a747a5201c748a67