### PR TITLE
Add screen dim listener callbacks

### DIFF
--- a/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
+++ b/android/smartfoo-android-lib-core/src/main/java/com/smartfoo/android/core/platform/FooScreenListener.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.display.DisplayManager;
+import android.os.Handler;
 import android.os.PowerManager;
 import android.os.UserManager;
 import android.view.Display;
@@ -26,6 +27,10 @@ public class FooScreenListener
         void onScreenOff();
 
         void onScreenOn();
+
+        void onScreenDim();
+
+        void onScreenUndim();
 
         void onUserUnlocked();
     }
@@ -68,6 +73,26 @@ public class FooScreenListener
                     }
 
                     @Override
+                    public void onScreenDim()
+                    {
+                        for (FooScreenListenerCallbacks callbacks : mListenerManager.beginTraversing())
+                        {
+                            callbacks.onScreenDim();
+                        }
+                        mListenerManager.endTraversing();
+                    }
+
+                    @Override
+                    public void onScreenUndim()
+                    {
+                        for (FooScreenListenerCallbacks callbacks : mListenerManager.beginTraversing())
+                        {
+                            callbacks.onScreenUndim();
+                        }
+                        mListenerManager.endTraversing();
+                    }
+
+                    @Override
                     public void onUserUnlocked()
                     {
                         for (FooScreenListenerCallbacks callbacks : mListenerManager.beginTraversing())
@@ -97,6 +122,11 @@ public class FooScreenListener
         return mScreenBroadcastReceiver.isScreenOn();
     }
 
+    public boolean isScreenDim()
+    {
+        return mScreenBroadcastReceiver.isScreenDim();
+    }
+
     public boolean isUserUnlocked()
     {
         boolean isUserUnlocked = mUserManager.isUserUnlocked();
@@ -119,18 +149,43 @@ public class FooScreenListener
     {
         private static final String TAG = FooLog.TAG(FooScreenBroadcastReceiver.class);
 
-        private final Context        mContext;
-        private final Object         mSyncLock;
-        private final DisplayManager mDisplayManager;
+        private final Context                        mContext;
+        private final Object                         mSyncLock;
+        private final DisplayManager                 mDisplayManager;
+        private final Handler                        mHandler;
+        private final DisplayManager.DisplayListener mDisplayListener;
 
         private boolean                    mIsStarted;
         private FooScreenListenerCallbacks mCallbacks;
+        private boolean                    mIsScreenOn;
+        private boolean                    mIsScreenDim;
 
         private FooScreenBroadcastReceiver(@NonNull Context context)
         {
             mContext = context;
             mSyncLock = new Object();
             mDisplayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+            mHandler = new Handler(context.getMainLooper());
+            mDisplayListener = new DisplayManager.DisplayListener()
+            {
+                @Override
+                public void onDisplayAdded(int displayId)
+                {
+                    refreshScreenState();
+                }
+
+                @Override
+                public void onDisplayChanged(int displayId)
+                {
+                    refreshScreenState();
+                }
+
+                @Override
+                public void onDisplayRemoved(int displayId)
+                {
+                    refreshScreenState();
+                }
+            };
         }
 
         public boolean isScreenOn()
@@ -145,6 +200,25 @@ public class FooScreenListener
                 }
             }
             return isScreenOn;
+        }
+
+        public boolean isScreenDim()
+        {
+            boolean isScreenDim = false;
+            for (Display display : mDisplayManager.getDisplays())
+            {
+                int state = display.getState();
+                if (state == Display.STATE_OFF)
+                {
+                    continue;
+                }
+                if (isDisplayStateDim(state))
+                {
+                    isScreenDim = true;
+                    break;
+                }
+            }
+            return isScreenDim;
         }
 
         public boolean isStarted()
@@ -166,9 +240,15 @@ public class FooScreenListener
 
                     mCallbacks = callbacks;
 
+                    mIsScreenOn = isScreenOn();
+                    mIsScreenDim = mIsScreenOn && isScreenDim();
+
+                    mDisplayManager.registerDisplayListener(mDisplayListener, mHandler);
+
                     IntentFilter intentFilter = new IntentFilter();
                     intentFilter.addAction(Intent.ACTION_SCREEN_OFF); // API 1
                     intentFilter.addAction(Intent.ACTION_SCREEN_ON); // API 1
+                    intentFilter.addAction(Intent.ACTION_USER_UNLOCKED); // API 24
                     mContext.registerReceiver(this, intentFilter);
                 }
             }
@@ -185,6 +265,11 @@ public class FooScreenListener
                     mIsStarted = false;
 
                     mContext.unregisterReceiver(this);
+                    mDisplayManager.unregisterDisplayListener(mDisplayListener);
+
+                    mCallbacks = null;
+                    mIsScreenOn = false;
+                    mIsScreenDim = false;
                 }
             }
             FooLog.v(TAG, "-stop()");
@@ -198,22 +283,112 @@ public class FooScreenListener
             switch (action)
             {
                 case Intent.ACTION_SCREEN_OFF:
-                    if (!isScreenOn())
-                    {
-                        mCallbacks.onScreenOff();
-                    }
+                    refreshScreenState();
                     break;
                 case Intent.ACTION_SCREEN_ON:
-                {
-                    if (isScreenOn())
+                    refreshScreenState();
+                    break;
+                case Intent.ACTION_USER_UNLOCKED:
+                    FooScreenListenerCallbacks callbacks;
+                    synchronized (mSyncLock)
                     {
-                        mCallbacks.onScreenOn();
+                        callbacks = mCallbacks;
+                    }
+                    if (callbacks != null)
+                    {
+                        callbacks.onUserUnlocked();
                     }
                     break;
+            }
+        }
+
+        private void refreshScreenState()
+        {
+            FooScreenListenerCallbacks callbacks;
+            boolean notifyScreenOff = false;
+            boolean notifyScreenOn = false;
+            boolean notifyScreenDim = false;
+            boolean notifyScreenUndim = false;
+
+            synchronized (mSyncLock)
+            {
+                if (!mIsStarted)
+                {
+                    return;
                 }
-                case Intent.ACTION_USER_UNLOCKED:
-                    mCallbacks.onUserUnlocked();
-                    break;
+
+                callbacks = mCallbacks;
+
+                boolean isScreenOn = isScreenOn();
+                if (mIsScreenOn != isScreenOn)
+                {
+                    mIsScreenOn = isScreenOn;
+                    if (isScreenOn)
+                    {
+                        notifyScreenOn = true;
+                    }
+                    else
+                    {
+                        notifyScreenOff = true;
+                        mIsScreenDim = false;
+                    }
+                }
+
+                if (mIsScreenOn)
+                {
+                    boolean isScreenDim = isScreenDim();
+                    if (mIsScreenDim != isScreenDim)
+                    {
+                        mIsScreenDim = isScreenDim;
+                        if (isScreenDim)
+                        {
+                            notifyScreenDim = true;
+                        }
+                        else
+                        {
+                            notifyScreenUndim = true;
+                        }
+                    }
+                }
+                else
+                {
+                    mIsScreenDim = false;
+                }
+            }
+
+            if (callbacks == null)
+            {
+                return;
+            }
+
+            if (notifyScreenOff)
+            {
+                callbacks.onScreenOff();
+            }
+            if (notifyScreenOn)
+            {
+                callbacks.onScreenOn();
+            }
+            if (notifyScreenDim)
+            {
+                callbacks.onScreenDim();
+            }
+            if (notifyScreenUndim)
+            {
+                callbacks.onScreenUndim();
+            }
+        }
+
+        private static boolean isDisplayStateDim(int state)
+        {
+            switch (state)
+            {
+                case Display.STATE_DOZE:
+                case Display.STATE_DOZE_SUSPEND:
+                case Display.STATE_ON_SUSPEND:
+                    return true;
+                default:
+                    return false;
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `FooScreenListener` with screen dim and undim callbacks
- add display listener wiring so dim/undim events follow display state changes and expose `isScreenDim()`

## Testing
- ./gradlew :smartfoo-android-lib-core:test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d708b95d788333bf7091e9ec14cf90